### PR TITLE
Update installation documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,10 @@ See the [releases page][releases] for the latest download links.
 The current installation method for these packages is to pull them in using
 `wget` or `curl` and install the local file with `apk`:
 
-```
-apk --no-cache add ca-certificates
-wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-http-parser/master/sgerrand.rsa.pub
-wget https://github.com/sgerrand/alpine-pkg-http-parser/releases/download/2.7.1-r0/http-parser-2.7.1-r0.apk
-apk --allow-untrusted add http-parser-2.7.1-r0.apk
-```
+    apk --no-cache add ca-certificates wget
+    wget --quiet --output-document=/etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub
+    wget https://github.com/sgerrand/alpine-pkg-http-parser/releases/download/2.7.1-r0/http-parser-2.7.1-r0.apk
+    apk --no-cache add http-parser-2.7.1-r0.apk
 
 [http-parser]: https://github.com/nodejs/http-parser
 [releases]: https://github.com/sgerrand/alpine-pkg-http-parser/releases/


### PR DESCRIPTION
💁 These changes update the package installation documentation to use a central key server for the public key used for signing to install using key verification.